### PR TITLE
Upgrade calls to `/licenses/*` endpoints

### DIFF
--- a/LemonSqueezy.Client/Abstractions/ILicenseKeyClient.cs
+++ b/LemonSqueezy.Client/Abstractions/ILicenseKeyClient.cs
@@ -8,9 +8,9 @@ namespace LemonSqueezy.Client.Abstractions
     public interface ILicenseKeyClient
     {
         Task<LicenseKey> GetLicenseKeyAsync(string licenseKeyId, CancellationToken cancellationToken = default);
-        Task<ApiResponseList<LicenseKey>> ListLicenseKeysAsync(CancellationToken cancellationToken = default);
-        Task<LicenseKey> ActivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default);
-        Task<LicenseKey> DeactivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default);
+      Task<ApiResponseList<LicenseKey>> ListLicenseKeysAsync(CancellationToken cancellationToken = default);
+        Task<ActivateLicenseKeyResponse> ActivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default);
+        Task<DeactivateLicenseKeyResponse> DeactivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default);
         Task<bool> ValidateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default);
     }
 }

--- a/LemonSqueezy.Client/Internal/HttpClients/LemonSqueezyHttpClient.cs
+++ b/LemonSqueezy.Client/Internal/HttpClients/LemonSqueezyHttpClient.cs
@@ -1,24 +1,22 @@
+using LemonSqueezy.Client.Abstractions;
+using LemonSqueezy.Client.Extensions;
+using LemonSqueezy.Client.Models.Abstractions;
+using LemonSqueezy.Client.Models.Customers;
+using LemonSqueezy.Client.Models.Files;
+using LemonSqueezy.Client.Models.LicenseKeys;
+using LemonSqueezy.Client.Models.OrderItems;
+using LemonSqueezy.Client.Models.Orders;
+using LemonSqueezy.Client.Models.Prices;
+using LemonSqueezy.Client.Models.Products;
+using LemonSqueezy.Client.Models.Stores;
+using LemonSqueezy.Client.Models.Subscriptions;
+using LemonSqueezy.Client.Models.Users;
+using LemonSqueezy.Client.Models.Variants;
 using System;
 using System.Net.Http;
-using LemonSqueezy.Client.Extensions;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using LemonSqueezy.Client.Abstractions;
-using LemonSqueezy.Client.Configuration;
-using LemonSqueezy.Client.Models.Abstractions;
-using LemonSqueezy.Client.Models.Users;
-using LemonSqueezy.Client.Models.Stores;
-using LemonSqueezy.Client.Models.Customers;
-using LemonSqueezy.Client.Models.Products;
-using LemonSqueezy.Client.Models.Variants;
-using LemonSqueezy.Client.Models.Prices;
-using LemonSqueezy.Client.Models.Files;
-using LemonSqueezy.Client.Models.Orders;
-using LemonSqueezy.Client.Models.OrderItems;
-using LemonSqueezy.Client.Models.Subscriptions;
-using LemonSqueezy.Client.Models.LicenseKeys;
 
 namespace LemonSqueezy.Client.Internal.HttpClients
 {
@@ -374,37 +372,37 @@ namespace LemonSqueezy.Client.Internal.HttpClients
             return result ?? throw new InvalidOperationException("Failed to deserialize response");
         }
 
-        public async Task<LicenseKey> ActivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default)
+        public async Task<ActivateLicenseKeyResponse> ActivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default)
         {
             var request = new ActivateLicenseKeyRequest(key, instance);
 
-            var response = await _httpClient.PostAsJsonAsync("license-keys/activate", request, _jsonOptions, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync("licenses/activate", request, _jsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<ApiResponse<LicenseKey>>(content, _jsonOptions);
+            var result = JsonSerializer.Deserialize<ActivateLicenseKeyResponse>(content, _jsonOptions);
 
-            return result?.Data ?? throw new InvalidOperationException("Failed to deserialize response");
+            return result ?? throw new InvalidOperationException("Failed to deserialize response");
         }
 
-        public async Task<LicenseKey> DeactivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default)
+        public async Task<DeactivateLicenseKeyResponse> DeactivateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default)
         {
             var request = new DeactivateLicenseKeyRequest(key, instance);
 
-            var response = await _httpClient.PostAsJsonAsync("license-keys/deactivate", request, _jsonOptions, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync("licenses/deactivate", request, _jsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<ApiResponse<LicenseKey>>(content, _jsonOptions);
+            var result = JsonSerializer.Deserialize<DeactivateLicenseKeyResponse>(content, _jsonOptions);
 
-            return result?.Data ?? throw new InvalidOperationException("Failed to deserialize response");
+            return result ?? throw new InvalidOperationException("Failed to deserialize response");
         }
 
         public async Task<bool> ValidateLicenseKeyAsync(string key, string instance, CancellationToken cancellationToken = default)
         {
             var request = new ValidateLicenseKeyRequest(key, instance);
 
-            var response = await _httpClient.PostAsJsonAsync("license-keys/validate", request, _jsonOptions, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync("licenses/validate", request, _jsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();

--- a/LemonSqueezy.Client/Models/LicenseKeys/ActivateLicenseKeyResponse.cs
+++ b/LemonSqueezy.Client/Models/LicenseKeys/ActivateLicenseKeyResponse.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace LemonSqueezy.Client.Models.LicenseKeys
+{
+    public class ActivateLicenseKeyResponse : LicenceKeyResponse
+    {
+        [JsonPropertyName("activated")]
+        public bool Activated { get; set; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+    }
+}

--- a/LemonSqueezy.Client/Models/LicenseKeys/DeactivateLicenseKeyResponse.cs
+++ b/LemonSqueezy.Client/Models/LicenseKeys/DeactivateLicenseKeyResponse.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace LemonSqueezy.Client.Models.LicenseKeys
+{
+    public class DeactivateLicenseKeyResponse : LicenceKeyResponse
+    {
+        [JsonPropertyName("deactivated")]
+        public bool Deactivated { get; set; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+    }
+}

--- a/LemonSqueezy.Client/Models/LicenseKeys/LicenceKeyResponse.cs
+++ b/LemonSqueezy.Client/Models/LicenseKeys/LicenceKeyResponse.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace LemonSqueezy.Client.Models.LicenseKeys
+{
+    public class LicenceKeyResponse
+    {
+        [JsonPropertyName("license_key")]
+        public LicenseKeyAttributes? LicenseKey { get; set; }
+
+        [JsonPropertyName("instance")]
+        public LicenceKeyInstance? Instance { get; set; }
+
+        [JsonPropertyName("meta")]
+        public LicenceKeyMeta? Meta { get; set; }
+    }
+
+    public class LicenceKeyInstance
+    {
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+    }
+
+    public class LicenceKeyMeta
+    {
+        [JsonPropertyName("store_id")]
+        public long StoreId { get; set; }
+
+        [JsonPropertyName("order_id")]
+        public long OrderId { get; set; }
+
+        [JsonPropertyName("order_item_id")]
+        public long OrderItemId { get; set; }
+
+        [JsonPropertyName("product_id")]
+        public long ProductId { get; set; }
+
+        [JsonPropertyName("product_name")]
+        public string? ProductName { get; set; }
+
+        [JsonPropertyName("variant_id")]
+        public long VariantId { get; set; }
+
+        [JsonPropertyName("variant_name")]
+        public string? VariantName { get; set; }
+
+        [JsonPropertyName("customer_id")]
+        public long CustomerId { get; set; }
+
+        [JsonPropertyName("customer_name")]
+        public string? CustomerName { get; set; }
+
+        [JsonPropertyName("customer_email")]
+        public string? CustomerEmail { get; set; }
+    }
+}

--- a/LemonSqueezy.Client/Models/LicenseKeys/LicenseKey.cs
+++ b/LemonSqueezy.Client/Models/LicenseKeys/LicenseKey.cs
@@ -38,7 +38,7 @@ namespace LemonSqueezy.Client.Models.LicenseKeys
         public string KeyShort { get; set; } = default!;
 
         [JsonPropertyName("activation_limit")]
-        public int ActivationLimit { get; set; }
+        public int? ActivationLimit { get; set; }
 
         [JsonPropertyName("instances_count")]
         public int InstancesCount { get; set; }

--- a/LemonSqueezy.Client/Models/LicenseKeys/ValidateLicenseKeyResponse.cs
+++ b/LemonSqueezy.Client/Models/LicenseKeys/ValidateLicenseKeyResponse.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace LemonSqueezy.Client.Models.LicenseKeys
 {
-    public class ValidateLicenseKeyResponse
+    public class ValidateLicenseKeyResponse : LicenceKeyResponse
     {
         [JsonPropertyName("valid")]
         public bool Valid { get; set; }


### PR DESCRIPTION
First off, this is an *excellent* package! Just what I needed.

I have updated the calls to `activate`, `deactivate` and `validate` for license keys as they don't match what's in the API docs.